### PR TITLE
Change status checking from !DOWN to UP

### DIFF
--- a/auth-request.lua
+++ b/auth-request.lua
@@ -67,7 +67,8 @@ core.register_action("auth-request", { "http-req" }, function(txn, be, path)
 	-- are not `DOWN`.
 	local addr = nil
 	for name, server in pairs(core.backends[be].servers) do
-		if server:get_stats()['status'] ~= "DOWN" then
+		local status = server:get_stats()['status']
+		if status == "no check" or status:find("UP") == 1 then
 			addr = server:get_addr()
 			break
 		end


### PR DESCRIPTION
HAProxy has also the MAINT status used on dynamic configuration. Changing from `!DOWN` to `UP` avoid using a disabled server from the farm.