### PR TITLE
Add x-auth-request-email header

### DIFF
--- a/auth-request.lua
+++ b/auth-request.lua
@@ -111,6 +111,7 @@ core.register_action("auth-request", { "http-req" }, function(txn, be, path)
 	if 200 <= c and c < 300 then
 		txn:set_var("txn.auth_response_successful", true)
 		txn:set_var("txn.auth_response_code", c)
+		txn:set_var("txn.auth_response_email", h["x-auth-request-email"])
 	-- 401 / 403: Do not allow request.
 	elseif c == 401 or c == 403 then
 		txn:set_var("txn.auth_response_code", c)


### PR DESCRIPTION
Add `x-auth-request-email` header received from bitly’s `oauth2_proxy`. Var isn’t assigned if the header doesn’t exist, without error or warning.