### PR TITLE
send_response: fix multi-valued response headers

### DIFF
--- a/auth-request.lua
+++ b/auth-request.lua
@@ -97,7 +97,7 @@ function send_response(txn, response, hdr_fail)
 	local reply = txn:reply()
 	if response then
 		reply:set_status(response.status_code)
-		for header, value in response:get_headers(true) do
+		for header, value in response:get_headers(false) do
 			if header_match(header, hdr_fail) then
 				reply:add_header(header, value)
 			end

--- a/test/headers_fail_multiple.vtc
+++ b/test/headers_fail_multiple.vtc
@@ -25,6 +25,20 @@ haproxy h1 -conf {
     listen fe1
         mode http
         bind "fd@${fe1}"
+
+        # VTest only sees the first header with a given name, thus
+        # we split the expected headers into separate headers that
+        # can be checked independently.
+        http-response set-header set-cookie1 %[res.fhdr(set-cookie,1)]
+        http-response set-header set-cookie2 %[res.fhdr(set-cookie,2)]
+        http-response set-header x-reason1 %[res.fhdr(x-reason,1)]
+        http-response set-header x-reason2 %[res.fhdr(x-reason,2)]
+
+        server be ${h1_fe2_addr}:${h1_fe2_port}
+
+    listen fe2
+        mode http
+        bind "fd@${fe2}"
         http-request lua.auth-intercept auth_backend / * * - x-user,x-reason,set-cookie
 
     backend auth_backend
@@ -39,14 +53,13 @@ client c1 -connect ${h1_fe1_sock} {
     expect resp.http.x-user == "admin"
     expect resp.http.x-passwd == "<undef>"
 
-    # vtest only sees the first value of a header
-    # but at least we can ensure they're not folded with commas
+    expect resp.http.x-reason !~ ","
+    expect resp.http.x-reason1 == "invalid pwd"
+    expect resp.http.x-reason2 == "account expired"
 
-    expect resp.http.x-reason == "invalid pwd"
-    #expect resp.http.x-reason == "account expired" # 2nd value, can't check
-
-    expect resp.http.set-cookie == "csrf=1234;"
-    #expect resp.http.set-cookie == "session=;" # 2nd value, can't check
+    expect resp.http.set-cookie !~ ","
+    expect resp.http.set-cookie1 == "csrf=1234;"
+    expect resp.http.set-cookie2 == "session=;"
 
     expect resp.body == "{\"msg\":\"invalid pwd\"}"
 } -run

--- a/test/headers_fail_multiple.vtc
+++ b/test/headers_fail_multiple.vtc
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: MIT
+
+varnishtest "Verify that multi-valued filtered auth backend response headers are passed to the client."
+feature ignore_unknown_macro
+feature cmd "dpkg --compare-versions ${haproxy_version} ge 2.2"
+
+server s_auth_backend {
+    rxreq
+    txresp \
+        -status 401 \
+        -hdr "x-user: admin" \
+        -hdr "x-passwd: 123" \
+        -hdr "x-reason: invalid pwd" \
+        -hdr "x-reason: account expired" \
+        -hdr "set-cookie: csrf=1234;" \
+        -hdr "set-cookie: session=;" \
+        -body "{\"msg\":\"invalid pwd\"}"
+} -start
+
+haproxy h1 -conf {
+    global
+        lua-prepend-path ${testdir}/../?/http.lua
+        lua-load ${testdir}/../auth-request.lua
+
+    listen fe1
+        mode http
+        bind "fd@${fe1}"
+        http-request lua.auth-intercept auth_backend / * * - x-user,x-reason,set-cookie
+
+    backend auth_backend
+        mode http
+        server auth_backend ${s_auth_backend_addr}:${s_auth_backend_port}
+} -start
+
+client c1 -connect ${h1_fe1_sock} {
+    txreq
+    rxresp
+    expect resp.status == 401
+    expect resp.http.x-user == "admin"
+    expect resp.http.x-passwd == "<undef>"
+
+    # vtest only sees the first value of a header
+    # but at least we can ensure they're not folded with commas
+
+    expect resp.http.x-reason == "invalid pwd"
+    #expect resp.http.x-reason == "account expired" # 2nd value, can't check
+
+    expect resp.http.set-cookie == "csrf=1234;"
+    #expect resp.http.set-cookie == "session=;" # 2nd value, can't check
+
+    expect resp.body == "{\"msg\":\"invalid pwd\"}"
+} -run


### PR DESCRIPTION
Joining the values with a comma, like get_headers(true) does, is invalid for some headers, eg. Set-Cookie.

Instead, use get_headers(false) to have separate loop iterations for each value of the header.
This way we have a separate add_header call for each value, and let haproxy take care of the rest.