### PR TITLE
fix: http.lua install path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,10 @@
 default:
 
 install: auth-request.lua haproxy-lua-http/http.lua
+	git submodule update --init
 	install -d "$(DESTDIR)/usr/share/haproxy"
-	install -m644 haproxy-lua-http/http.lua "$(DESTDIR)/usr/share/haproxy"
+        install -d "$(DESTDIR)/usr/share/haproxy/haproxy-lua-http"
+	install -m644 haproxy-lua-http/http.lua "$(DESTDIR)/usr/share/haproxy/haproxy-lua-http"
 	install -m644 auth-request.lua "$(DESTDIR)/usr/share/haproxy"
 
 .PHONY: install


### PR DESCRIPTION
The original Makefile will install the http.lua to the root of /usr/share/haproxy